### PR TITLE
Update Node.js engine requirement to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eject": "react-scripts eject"
   },
   "engines": {
-    "node": "16.1.0",
+    "node": "24.x",
     "npm": "8.0.0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "engines": {
     "node": "24.x",
-    "npm": "8.0.0"
+    "npm": ">=8.0.0"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Updates the `engines.node` field in `package.json` to `"24.x"` as requested to fix the "Found invalid or discontinued Node.js Version: 16.1.0" error.

---
*PR created automatically by Jules for task [12176400524817516043](https://jules.google.com/task/12176400524817516043) started by @Felipe-Fidalgo*