### PR TITLE
fix: update node.js version constraint in package.json to 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eject": "react-scripts eject"
   },
   "engines": {
-    "node": "16.1.0",
+    "node": "24.x",
     "npm": "8.0.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
Set engines.node to 24.x to resolve the invalid/discontinued
Node.js version error and ensure compatibility.

---
*PR created automatically by Jules for task [12322404920360242305](https://jules.google.com/task/12322404920360242305) started by @Felipe-Fidalgo*