### PR TITLE
fix: Update npm engine requirement in package.json to >=8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "engines": {
     "node": "24.x",
-    "npm": "8.0.0"
+    "npm": ">=8.0.0"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This change allows users to run the project with newer versions of npm
(e.g., 11.x) without encountering an EBADENGINE warning, while still
requiring a minimum version of 8.0.0.

---
*PR created automatically by Jules for task [5909723752934097208](https://jules.google.com/task/5909723752934097208) started by @Felipe-Fidalgo*