### PR TITLE
Fix white space at bottom of page

### DIFF
--- a/src/components/BaseLayout.js
+++ b/src/components/BaseLayout.js
@@ -23,7 +23,7 @@ export default function BaseLayout() {
             <Grid item>
                 <Navbar darkMode={darkMode} handleClick={handleClick}/>
             </Grid>
-            <Grid marginBottom={50} item flexGrow={2}>
+            <Grid paddingBottom={10} item flexGrow={2}>
                <div id="inicio">
                   <Home darkMode={darkMode}/>
                </div>


### PR DESCRIPTION
Replaced `marginBottom={50}` with `paddingBottom={10}` on the main content Grid item in `src/components/BaseLayout.js`. This allows the container's background color (green) to extend all the way to the bottom, instead of revealing the default white body background underneath the margin.

---
*PR created automatically by Jules for task [13677140144924744](https://jules.google.com/task/13677140144924744) started by @Felipe-Fidalgo*