### PR TITLE
style: update body background to use theme gradient

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -8,7 +8,8 @@ body {
     width: 100%;
     height: 100%;
     color: $dark;
-    background-color: $white;
+    background: linear-gradient(#000000 10%, #015308);
+    background-attachment: fixed;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
Foi atualizado o `App.module.scss` para utilizar o mesmo gradiente do tema escuro como plano de fundo padrão no lugar do branco (`$white`), e foi fixado na tela (`background-attachment: fixed`).

---
*PR created automatically by Jules for task [9558599902072670258](https://jules.google.com/task/9558599902072670258) started by @Felipe-Fidalgo*